### PR TITLE
Fixed PNG download

### DIFF
--- a/src/util/editor/graphFunctions.js
+++ b/src/util/editor/graphFunctions.js
@@ -148,7 +148,7 @@ class GraphFunctions {
       canvas.width = svgImage.clientWidth;
       canvas.height = svgImage.clientHeight;
       const canvasCtx = canvas.getContext("2d");
-      canvasCtx.drawImage(svgImage, 0, 0);
+      canvasCtx.drawImage(svgImage, 0, 0, canvas.width, canvas.height);
       const imgData = canvas.toDataURL("image/png");
       const element = document.createElement("a");
       element.download = "w3c.png";


### PR DESCRIPTION
Fixed the PNG downloader on graph editor so it eliminates all the whitespace<img width="830" alt="Screenshot 2024-01-29 at 1 31 50 PM" src="https://github.com/acm-ucr/r-tools/assets/112200249/a6a1b3c4-04f1-481b-bbdd-29eaca70d38c">